### PR TITLE
refactor: Move fork_bomb from func to module

### DIFF
--- a/agent/fork_bomb.c
+++ b/agent/fork_bomb.c
@@ -1,0 +1,20 @@
+#include <uapi/linux/ptrace.h>
+#include <linux/sched.h>
+
+BPF_HASH(fork_count, u32, u64);
+
+int trace_fork(struct pt_regs *ctx) {
+    u32 pid = bpf_get_current_pid_tgid() >> 32;
+    u64 zero = 0, *count;
+
+    count = fork_count.lookup_or_init(&pid, &zero);
+    (*count)++;
+
+    // Print information when the count exceeds a threshold
+    if (*count > 10) {
+        bpf_trace_printk("%u %u %llu", pid, bpf_get_current_pid_tgid(), *count);
+    }
+
+    return 0;
+}
+


### PR DESCRIPTION
This PR refactors the `ebpf_agent.py` program by moving the `fork_bomb()` function from it into an external module.
This will allow better scalability and maintenance of the code, while supporting additional ebpf programs to detect new metrics.

Co-Authored-By: Idan Kalmanzon idankalmanzon@gmail.com