### PR TITLE
fix: Reformat log as JSON

### DIFF
--- a/agent/ebpf_agent.py
+++ b/agent/ebpf_agent.py
@@ -25,9 +25,9 @@ b_port_scan = BPF(src_file="port_scan.c")
 b_login_attempt = BPF(src_file="login_attempt.c")
 b_sudo_command = BPF(src_file="sudo_command.c")
 
-def send_metrics(log_entry):
-    #print(log_entry)
-    requests.post("http://10.10.248.155:5000/data", json=log_obj)
+def send_metrics(log_obj):
+    print(log_obj)
+    #requests.post("http://10.10.248.155:5000/data", json=log_obj)
 
 def handle_fork_bomb_trace(b, hostname):
     while True:
@@ -41,23 +41,44 @@ def handle_fork_bomb_trace(b, hostname):
                 log_count = int(parts[2])
                 timestamp = str(datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ"))
                 
-                log_entry = f"PID {log_pid} forked {log_count} subprocesses on {hostname} at {timestamp}"
-                send_metrics(log_entry)
+                log_entry = f"PID {log_pid} forked {log_count} subprocesses"
+                log_obj = {
+                    "Time": f"{timestamp}",
+                    "Type": f"fork bomb",
+                    "Target": f"{hostname}",
+                    "Info": f"{log_entry}"
+                }                
+
+                send_metrics(log_obj)
 
 def handle_file_creation(cpu, data, size):
     event = b_file_creation["events"].event(data)
     timestamp = str(datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ"))
     filename = event.filename.decode('utf-8')
     username = pwd.getpwuid(event.uid).pw_name
-    log_entry = f"User {username} with UID {event.uid} created file {filename} on {hostname} at {timestamp}"
-    send_metrics(log_entry)
+    log_entry = f"User {username} with UID {event.uid} created file {filename}"
+    log_obj = {
+        "Time": f"{timestamp}",
+        "Type": f"file creation",
+        "Target": f"{hostname}",
+        "Info": f"{log_entry}"
+    }
+
+    send_metrics(log_obj)
 
 def handle_port_scan(cpu, data, size):
     event = ctypes.cast(data, ctypes.POINTER(Event)).contents
     timestamp = str(datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ"))
     source_ip = socket.inet_ntoa(ctypes.c_uint32(event.src_ip).value.to_bytes(4, 'little'))
-    log_entry = f"Host {source_ip} scanned {event.count} ports on {hostname} at {timestamp}"
-    send_metrics(log_entry)
+    log_entry = f"Host {source_ip} scanned {event.count} ports"
+    log_obj = {
+        "Time": f"{timestamp}",
+        "Type": f"port scan",
+        "Target": f"{hostname}",
+        "Info": f"{log_entry}"
+    } 
+
+    send_metrics(log_obj)
 
 def handle_login_attempt(cpu, data, size):
     event = b_login_attempt["events"].event(data)
@@ -65,8 +86,15 @@ def handle_login_attempt(cpu, data, size):
         timestamp = str(datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ"))
         username = pwd.getpwuid(event.uid).pw_name
         source_ip = subprocess.run(f"ss -tp | grep ssh | grep $(ps -o ppid= -p {event.pid}) | awk -F: '{{print $8}}' | sed 's/]//g'", shell=True, capture_output=True, text=True).stdout.strip()
-        log_entry = f"User {username} with UID {event.uid} successfully logged-in via SSH from {source_ip} to {hostname} at {timestamp}"
-        send_metrics(log_entry)
+        log_entry = f"User {username} with UID {event.uid} successfully logged-in via SSH from {source_ip}"
+        log_obj = {
+            "Time": f"{timestamp}",
+            "Type": f"login attempt",
+            "Target": f"{hostname}",
+            "Info": f"{log_entry}"
+        }
+
+        send_metrics(log_obj)
 
 def handle_sudo_command(cpu, data, size):
     event = b_sudo_command["events"].event(data)
@@ -75,8 +103,15 @@ def handle_sudo_command(cpu, data, size):
         command = subprocess.run(f"ps -p {event.pid} -o args --no-headers", shell=True, capture_output=True, text=True).stdout.strip()
         if command and 'sudo' in command:
             username = pwd.getpwuid(event.uid).pw_name
-            log_entry = f"User {username} with UID {event.uid} executed command '{command}' on {hostname} at {timestamp}"
-            send_metrics(log_entry)
+            log_entry = f"User {username} with UID {event.uid} executed command '{command}'"
+            log_obj = {
+                "Time": f"{timestamp}",
+                "Type": f"sudo command",
+                "Target": f"{hostname}",
+                "Info": f"{log_entry}"
+            }            
+
+            send_metrics(log_obj)
 
 def monitor_fork_bomb_trace():
     b_fork_bomb.attach_kprobe(event="__x64_sys_clone", fn_name="trace_fork")

--- a/agent/ebpf_agent.py
+++ b/agent/ebpf_agent.py
@@ -26,8 +26,8 @@ b_login_attempt = BPF(src_file="login_attempt.c")
 b_sudo_command = BPF(src_file="sudo_command.c")
 
 def send_metrics(log_obj):
-    print(log_obj)
-    #requests.post("http://10.10.248.155:5000/data", json=log_obj)
+    #print(log_obj)
+    requests.post("http://10.10.248.155:5000/data", json=log_obj)
 
 def handle_fork_bomb_trace(b, hostname):
     while True:

--- a/attacks/login_attempt.sh
+++ b/attacks/login_attempt.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+read -p "Enter the IP address: " IP_ADDRESS
+
+# Check if the IP address is not empty
+if [ -z "$IP_ADDRESS" ]; then
+    echo "IP address cannot be empty. Exiting."
+    exit 1
+fi
+
+# SSH into the provided IP address
+ssh "$IP_ADDRESS"
+


### PR DESCRIPTION
This PR reformats the log entry as JSON.
In addition, it adds a new login attempt attack.

```
Tracing cybersecurity events... Ctrl-C to end.
{'Time': '2024-08-07T19:46:39Z', 'Type': 'sudo command', 'Target': '10.10.248.158', 'Info': "User cs401 with UID 1001 executed command 'sudo touch /etc/a'"}
{'Time': '2024-08-07T19:46:43Z', 'Type': 'file creation', 'Target': '10.10.248.158', 'Info': 'User root with UID 0 created file /etc/a'}
{'Time': '2024-08-07T19:48:10Z', 'Type': 'login attempt', 'Target': '10.10.248.158', 'Info': 'User cs401 with UID 1001 successfully logged-in via SSH from 10.10.248.158'}
{'Time': '2024-08-07T19:50:04Z', 'Type': 'port scan', 'Target': '10.10.248.158', 'Info': 'Host 8.8.4.4 scanned 11 ports'}
{'Time': '2024-08-07T19:50:21Z', 'Type': 'fork bomb', 'Target': '10.10.248.158', 'Info': 'PID 3452771 forked 101 subprocesses'}
```